### PR TITLE
Fix tests with custom docker image

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,15 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/imposd/llvm-ubuntu:latest
 
     steps:
     - uses: actions/checkout@v3
+    
     - name: Build
       run: cargo build --verbose
+
     - name: Run tests
       run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Set rustup version
+      run: rustup default stable
     
     - name: Build
       run: cargo build --verbose


### PR DESCRIPTION
I was able to fix the tests using a custom docker image, before the tests would fail because LLVM wasn't installed, instead of installing the needed dependencies every time, we now use a custom Ubuntu image with everything sorted.